### PR TITLE
Remove recursive argument to get_metrics

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -186,7 +186,7 @@ def main():
         run.wait_for_completion(show_output=True)
 
         # Creating additional outputs of finished run
-        run_metrics = run.get_metrics(recursive=True)
+        run_metrics = run.get_metrics()
         print(f"::set-output name=run_metrics::{run_metrics}")
         run_metrics_markdown = convert_to_markdown(run_metrics)
         print(f"::set-output name=run_metrics_markdown::{run_metrics_markdown}")


### PR DESCRIPTION
Using azureml-sdk 1.21.0 and getting

```
Traceback (most recent call last):
  File "/code/main.py", line 238, in <module>
    main()
  File "/code/main.py", line 189, in main
    run_metrics = run.get_metrics(recursive=True)
TypeError: get_metrics() got an unexpected keyword argument 'recursive'
```